### PR TITLE
feat: invalidate cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,10 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const async = require('async');
 const loaderUtils = require('loader-utils');
-const pkg = require('../package.json');
+const pkgVersion = require('../package.json').version;
 
 const defaultCacheDirectory = path.resolve('.cache-loader');
+const ENV = process.env.NODE_ENV || 'development';
 
 function loader(...args) {
   const callback = this.async();
@@ -65,16 +66,13 @@ function pitch(remainingRequest, prevRequest, dataInput) {
   const loaderOptions = loaderUtils.getOptions(this) || {};
   const defaultOptions = {
     cacheDirectory: defaultCacheDirectory,
-    cacheIdentifier: JSON.stringify({
-      'cache-loader': pkg.version,
-      env: process.env.NODE_ENV || 'development',
-    }),
+    cacheIdentifier: `cache-loader:${pkgVersion} ${ENV}`,
   };
   const options = Object.assign({}, defaultOptions, loaderOptions);
   const { cacheIdentifier, cacheDirectory } = options;
   const data = dataInput;
   const callback = this.async();
-  const hash = digest(remainingRequest + cacheIdentifier);
+  const hash = digest(`${cacheIdentifier}\n${remainingRequest}`);
   const cacheFile = path.join(cacheDirectory, `${hash}.json`);
   data.remainingRequest = remainingRequest;
   data.cacheIdentifier = cacheIdentifier;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ function loader(...args) {
     const writeCacheFile = () => {
       fs.writeFile(data.cacheFile, JSON.stringify({
         remainingRequest: data.remainingRequest,
+        cacheIdentifier: data.cacheIdentifier,
         dependencies: deps,
         contextDependencies: contextDeps,
         result: args,
@@ -76,6 +77,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
   const hash = digest(remainingRequest + cacheIdentifier);
   const cacheFile = path.join(cacheDirectory, `${hash}.json`);
   data.remainingRequest = remainingRequest;
+  data.cacheIdentifier = cacheIdentifier;
   data.cacheFile = cacheFile;
   fs.readFile(cacheFile, 'utf-8', (readFileErr, content) => {
     if (readFileErr) {
@@ -90,7 +92,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
       callback();
       return;
     }
-    if (cacheData.remainingRequest !== remainingRequest) {
+    if (cacheData.remainingRequest !== remainingRequest || cacheData.cacheIdentifier !== cacheIdentifier) {
       // in case of a hash conflict
       callback();
       return;


### PR DESCRIPTION
Steps:
- [x] Add ability to determinate own cache identifier.
- [x] Invalidate cache after `cache-loader` updated.
- [x] Invalidate cache after `cache-loader` options changed.
- [x] Invalidate cache if environment changed.
- [x] Invalidate cache if loader in chain updated.
As sokra says:
```
"postinstall": "rm -rf .cache-loader"
```
We can just add this in README.
- [x] Search solution for loaders using fs based configuration files, maybe just add docs.
As sokra says:
```
configuration files -> loaders should add these files to their dependencies (with `this.addDependency`). dependencies' mtimes are stored by the cache-loader
```
Partial fixed: https://github.com/webpack-contrib/cache-loader/issues/3