### PR TITLE
perf(index): use the `compiler`'s cached `fs` for stats (`this.fs.stat`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function loader(...args) {
   let cache = true;
 
   const toDepDetails = (dep, mapCallback) => {
-    fs.stat(dep, (err, stats) => {
+    this.fs.stat(dep, (err, stats) => {
       if (err) {
         mapCallback(err);
         return;
@@ -110,7 +110,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
       return;
     }
     async.each(cacheData.dependencies.concat(cacheData.contextDependencies), (dep, eachCallback) => {
-      fs.stat(dep.path, (statErr, stats) => {
+      this.fs.stat(dep.path, (statErr, stats) => {
         if (statErr) {
           eachCallback(statErr);
           return;


### PR DESCRIPTION
Related to https://github.com/webpack-contrib/cache-loader/issues/35

I was experiencing a similar issue to that described in https://github.com/webpack-contrib/cache-loader/issues/10#issuecomment-374986963

> In my experience, with cache-loader rebuild time increased dramatically – from 2.5s to 9.5s. While initial build time decreased for ~40s.

After profiling incremental builds it looks like `fs.stat` is the biggest bottle neck, specifically when validating a cache entry after a hit:

https://github.com/webpack-contrib/cache-loader/blob/74fccc4407750942c8a082906309f8af298c16e8/src/index.js#L112-L114

This change decreased my incremental build times back down below 1s.