### PR TITLE
use the `compiler`'s cached `fs` for stats if there, otherwise, fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function loader(...args) {
   let cache = true;
 
   const toDepDetails = (dep, mapCallback) => {
-    this.fs.stat(dep, (err, stats) => {
+    (this.fs || fs).stat(dep, (err, stats) => {
       if (err) {
         mapCallback(err);
         return;
@@ -110,7 +110,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
       return;
     }
     async.each(cacheData.dependencies.concat(cacheData.contextDependencies), (dep, eachCallback) => {
-      this.fs.stat(dep.path, (statErr, stats) => {
+      (this.fs || fs).stat(dep.path, (statErr, stats) => {
         if (statErr) {
           eachCallback(statErr);
           return;


### PR DESCRIPTION
Fixes undefined `this.fs` when behind thread-loader