### PR TITLE
chore: drop support for `webpack` < 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "webpack-defaults": "^1.6.0"
   },
   "engines": {
-    "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
+    "node": ">= 6.9.0"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "webpack": "^4.0.0"
   },
   "repository": "https://github.com/webpack-contrib/cache-loader.git",
   "bugs": "https://github.com/webpack-contrib/cache-loader/issues",


### PR DESCRIPTION
BREAKING CHANGE: drop support for `webpack` < 4

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
