### PR TITLE
Generate normalized cache context relative paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5668,7 +5668,7 @@
     },
     "git-config-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "dev": true,
       "requires": {
@@ -9029,8 +9029,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-path": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "loader-utils": "^1.1.0",
     "mkdirp": "^0.5.1",
     "neo-async": "^2.6.0",
+    "normalize-path": "^3.0.0",
     "schema-utils": "^1.0.0"
   },
   "devDependencies": {
@@ -66,7 +67,6 @@
     "jest": "^23.6.0",
     "lint-staged": "^8.1.0",
     "memory-fs": "^0.4.1",
-    "normalize-path": "^3.0.0",
     "pre-commit": "^1.0.0",
     "prettier": "^1.15.2",
     "standard-version": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 */
 const fs = require('fs');
 const path = require('path');
+const normalizePath = require('normalize-path');
 const async = require('neo-async');
 const crypto = require('crypto');
 const mkdirp = require('mkdirp');
@@ -33,13 +34,13 @@ function pathWithCacheContext(cacheContext, originalPath) {
   if (originalPath.includes(cacheContext)) {
     return originalPath
       .split('!')
-      .map((subPath) => path.relative(cacheContext, subPath))
+      .map((subPath) => normalizePath(path.relative(cacheContext, subPath)))
       .join('!');
   }
 
   return originalPath
     .split('!')
-    .map((subPath) => path.resolve(cacheContext, subPath))
+    .map((subPath) => normalizePath(path.resolve(cacheContext, subPath)))
     .join('!');
 }
 

--- a/test/__snapshots__/cacheContext-option.test.js.snap
+++ b/test/__snapshots__/cacheContext-option.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cacheContext option should generate absolute paths to the project root 2: errors 1`] = `Array []`;
+exports[`cacheContext option should generate absolute paths to the project root: errors 1`] = `Array []`;
 
-exports[`cacheContext option should generate absolute paths to the project root 2: warnings 1`] = `Array []`;
+exports[`cacheContext option should generate absolute paths to the project root: warnings 1`] = `Array []`;
 
 exports[`cacheContext option should generate relative paths to the project root: errors 1`] = `Array []`;
 


### PR DESCRIPTION
This PR enables the cache context relative paths generation to always use normalized posix paths instead of specific OS ones.

\CC @evilebottnawi