### PR TITLE
Fix broken tests badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm][npm]][npm-url]
 [![node][node]][node-url]
 [![deps][deps]][deps-url]
-[![test][test]][test-url]
+[![tests][tests]][tests-url]
 [![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
 [![size][size]][size-url]


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Additional Info

The tests badge was broken in https://github.com/webpack-contrib/cache-loader/commit/a55741d660de5b642f6d0e581f718863603c2dfe#diff-04c6e90faac2675aa89e2176d2eec7d8L207 

Found via webpack docs link checker on the `rebuild` branch: https://travis-ci.org/webpack/webpack.js.org/jobs/479654517#L1187-L1191

![image](https://user-images.githubusercontent.com/331790/51149574-fa7f0200-1862-11e9-9ac0-cbdd225489c8.png)
