### PR TITLE
Read only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm][npm]][npm-url]
 [![node][node]][node-url]
 [![deps][deps]][deps-url]
-[![test][test]][test-url]
+[![tests][tests]][tests-url]
 [![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
 [![size][size]][size-url]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm][npm]][npm-url]
 [![node][node]][node-url]
 [![deps][deps]][deps-url]
-[![tests][tests]][tests-url]
+[![test][test]][test-url]
 [![coverage][cover]][cover-url]
 [![chat][chat]][chat-url]
 [![size][size]][size-url]
@@ -54,6 +54,7 @@ module.exports = {
 | **`cacheIdentifier`** |                    `{String}`                    | `cache-loader:{version} {process.env.NODE_ENV}` | Provide an invalidation identifier which is used to generate the hashes. You can use it for extra dependencies of loaders (used for default read/write implementation) |
 |      **`write`**      | `{Function(cacheKey, data, callback) -> {void}}` |                   `undefined`                   | Allows you to override default write cache data to file (e.g. Redis, memcached)                                                                                        |
 |      **`read`**       |    `{Function(cacheKey, callback) -> {void}}`    |                   `undefined`                   | Allows you to override default read cache data from file                                                                                                               |
+|    **`readOnly`**     |                    `{Boolean}`                   |                   `false`                       | Allows you to override default value and make the cache read only (useful for some environments where you don't want the cache to be updated, only read from it)       |
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,8 @@ function loader(...args) {
 
   const { readOnly, write: writeFn } = options;
 
+  // In case we are under a readOnly mode on cache-loader
+  // we don't want to write or update any cache file
   if (readOnly) {
     this.callback(null, ...args);
     return;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const defaults = {
   cacheIdentifier: `cache-loader:${pkg.version} ${env}`,
   cacheKey,
   read,
+  readOnly: false,
   write,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -162,10 +162,15 @@ function pitch(remainingRequest, prevRequest, dataInput) {
             eachCallback(statErr);
             return;
           }
+
+          // When we are under a readOnly config on cache-loader
+          // we don't want to emit any other error than a
+          // file stat error
           if (readOnly) {
             eachCallback();
             return;
           }
+
           if (stats.mtime.getTime() !== dep.mtime) {
             eachCallback(true);
             return;

--- a/src/options.json
+++ b/src/options.json
@@ -18,6 +18,9 @@
     },
     "write": {
       "instanceof": "Function"
+    },
+    "readOnly": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/src/options.json
+++ b/src/options.json
@@ -16,11 +16,11 @@
     "read": {
       "instanceof": "Function"
     },
-    "write": {
-      "instanceof": "Function"
-    },
     "readOnly": {
       "type": "boolean"
+    },
+    "write": {
+      "instanceof": "Function"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
In some environments it useful to not write anything the cache and just using it in read-only mode ( for example in a CI environment or even in a production environment running the webpack build for some reason ).

This PR along with other already merged (https://github.com/webpack-contrib/cache-loader/pull/49) will gave us the ability to run cache-loader, with pre-built caches, in almost every environment we wanna use it.

/CC @evilebottnawi 