### PR TITLE
feat: add option for custom compare function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ module.exports = {
 | **`cacheIdentifier`** |                    `{String}`                    |     `cache-loader:{version} {process.env.NODE_ENV}`     | Provide an invalidation identifier which is used to generate the hashes. You can use it for extra dependencies of loaders (used for default read/write implementation) |
 |      **`write`**      | `{Function(cacheKey, data, callback) -> {void}}` |                       `undefined`                       | Allows you to override default write cache data to file (e.g. Redis, memcached)                                                                                        |
 |      **`read`**       |    `{Function(cacheKey, callback) -> {void}}`    |                       `undefined`                       | Allows you to override default read cache data from file                                                                                                               |
+|      **`compare`**    |    `{Function(stats, dep) -> {Boolean}}`         |                       `undefined`                       | Allows you to override default comparison. Return `true` to use cache                                                                                                     |
 |    **`readOnly`**     |                   `{Boolean}`                    |                         `false`                         | Allows you to override default value and make the cache read only (useful for some environments where you don't want the cache to be updated, only read from it)       |
 
 ## Examples

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const defaults = {
   read,
   readOnly: false,
   write,
+  compare,
 };
 
 function pathWithCacheContext(cacheContext, originalPath) {
@@ -138,6 +139,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
     readOnly,
     cacheContext,
     cacheKey: cacheKeyFn,
+    compare: compareFn,
   } = options;
 
   const callback = this.async();
@@ -173,7 +175,7 @@ function pitch(remainingRequest, prevRequest, dataInput) {
             return;
           }
 
-          if (stats.mtime.getTime() !== dep.mtime) {
+          if (compareFn(stats, dep) !== true) {
             eachCallback(true);
             return;
           }
@@ -251,6 +253,10 @@ function cacheKey(options, request) {
   const hash = digest(`${cacheIdentifier}\n${request}`);
 
   return path.join(cacheDirectory, `${hash}.json`);
+}
+
+function compare(stats, dep) {
+  return stats.mtime.getTime() === dep.mtime;
 }
 
 export const raw = true;

--- a/src/options.json
+++ b/src/options.json
@@ -21,6 +21,9 @@
     },
     "write": {
       "instanceof": "Function"
+    },
+    "compare": {
+      "instanceof": "Function"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
It's not always reliable to use `mtime`, so allowing for a `compare` function to be passed makes it possible for custom logic to be used. (ie. hashing)

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In our CI environment, the `mtime` doesn't always match when it probably should, so we'd like to use something else (like file hashing). This is a simple update to expose a `compare` option that can be used to provide custom logic.

It's been mentioned before (#34 #41 #29)

### Breaking Changes

No breaking changes

### Additional Info

I started writing some tests, but I'm not sure how best to test this update...