### PR TITLE
feat: add "precision" option for rounding mtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ module.exports = {
 |      **`read`**       |    `{Function(cacheKey, callback) -> {void}}`    |                       `undefined`                       | Allows you to override default read cache data from file                                                                                                               |
 |      **`compare`**    |    `{Function(stats, dep) -> {Boolean}}`         |                       `undefined`                       | Allows you to override default comparison function between the cached dependency and the one is being read. Return `true` to use the cached resource.                                                                                                    |
 |    **`readOnly`**     |                   `{Boolean}`                    |                         `false`                         | Allows you to override default value and make the cache read only (useful for some environments where you don't want the cache to be updated, only read from it)       |
+|    **`precision`**    |                   `{Number}`                     |                         `0`                             | Round `mtime` by this number of milliseconds before comparing         |
 
 ## Examples
 

--- a/src/options.json
+++ b/src/options.json
@@ -24,6 +24,9 @@
     },
     "compare": {
       "instanceof": "Function"
+    },
+    "precision": {
+      "type": "number"
     }
   },
   "additionalProperties": false

--- a/test/precision.test.js
+++ b/test/precision.test.js
@@ -1,0 +1,42 @@
+const { webpack } = require('./helpers');
+
+const testId = './basic/index.js';
+
+const isRounded = (ms, precision) =>
+  typeof ms === 'number' &&
+  ms === (Math.floor(ms / precision || 1) * precision || 1);
+
+const compareFn = jest.fn().mockName('compareFn');
+
+function makeConfig(precision) {
+  compareFn
+    .mockReset()
+    .mockImplementation(
+      (stats, dep) =>
+        isRounded(stats.mtime.getTime(), precision) &&
+        isRounded(dep.mtime, precision)
+    );
+
+  return {
+    loader: {
+      options: {
+        ...(precision && { precision }),
+        compare: (...args) => compareFn(...args),
+      },
+    },
+  };
+}
+
+describe('precision option', () => {
+  it('should not round by default', async () => {
+    await webpack(testId, makeConfig());
+  });
+
+  it('should round mtime', async () => {
+    await webpack(testId, makeConfig(1000));
+    expect(compareFn).toHaveReturnedWith(true);
+
+    await webpack(testId, makeConfig(345));
+    expect(compareFn).toHaveReturnedWith(true);
+  });
+});


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In our CI environment, we use `tar` to share files between build servers. By default, `tar` truncates the milliseconds off the `mtime`, so unless a file just happened to be saved on an exact second, the `cache-loader` will ignore the cache for that file.

By adding a `precision` option, we will be able to set `precision: 1000` to round the `mtime` in our comparisons to ensure that the cached mtimes match the files that were restored from tar.

### Breaking Changes

By defaulting the `precision` option to `0`, the current behavior is unchanged, and there are no breaking changes.

### Additional Info

I'm still writing tests for this change...