### PR TITLE
feat: make cacheDirectory configurable by env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,10 @@ const schema = require('./options.json');
 
 const defaults = {
   cacheContext: '',
-  cacheDirectory: findCacheDir({ name: 'cache-loader' }) || os.tmpdir(),
+  cacheDirectory:
+    process.env.CACHE_LOADER_CACHE_DIR ||
+    findCacheDir({ name: 'cache-loader' }) ||
+    os.tmpdir(),
   cacheIdentifier: `cache-loader:${pkg.version} ${env}`,
   cacheKey,
   compare,


### PR DESCRIPTION


This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Adds option to control the `cacheDirectory` with `CACHE_LOADER_CACHE_DIR`. Useful for keeping the default for local dev environment and controlling the value on CI/CD.

The `cacheDirectory`option still takes precedence if specified.

https://github.com/webpack-contrib/cache-loader/issues/91

### Breaking Changes

Only changes behaviour if someone has the `CACHE_LOADER_CACHE_DIR` variable set in their environment - very unlikely it's a breaking change.

### Additional Info
#### To do
* [ ] Add docs if feature accepted